### PR TITLE
Fix provides section

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -15,6 +15,6 @@
     "Rabble::Verbs::IO"          : "lib/Rabble/Verbs/IO.pm6",
     "Rabble::Verbs::Shufflers"   : "lib/Rabble/Verbs/Shufflers.pm6",
     "Rabble::Verbs::StackOps"    : "lib/Rabble/Verbs/StackOps.pm6",
-    "rabble"                     : "bin/rabble"
+    "Rabble::Util"               : "lib/Rabble/Util.pm6"
   }
 }


### PR DESCRIPTION
Util.pm6 has to be not listed in META6.json, and there is no need to list `bin` there.